### PR TITLE
fix: Improve regex to handle different repo URL formats



### DIFF
--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -224,7 +224,7 @@ class PullCraft {
         return __awaiter(this, void 0, void 0, function* () {
             try {
                 const repoUrl = yield this.git.raw(['config', '--get', 'remote.origin.url']);
-                const match = repoUrl.match(/github\.com[:/](.+?)\/(.+?)\.git/);
+                const match = repoUrl.trim().match(/github\.com[:/](.+?)\/(.+?)(\.git)?$/);
                 if (match) {
                     return { owner: match[1], repo: match[2] };
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,7 +240,7 @@ export class PullCraft {
   async getRepoInfo (): Promise<{ owner: string, repo: string }> {
     try {
       const repoUrl = await this.git.raw(['config', '--get', 'remote.origin.url']);
-      const match = repoUrl.match(/github\.com[:/](.+?)\/(.+?)\.git/);
+      const match = repoUrl.trim().match(/github\.com[:/](.+?)\/(.+?)(\.git)?$/);
       if (match) {
         return { owner: match[1], repo: match[2] };
       }

--- a/test/pullcraft.test.ts
+++ b/test/pullcraft.test.ts
@@ -157,8 +157,14 @@ describe('PullCraft', () => {
   });
 
   describe('getRepoInfo', () => {
-    it('should get repository info', async () => {
+    it('should get repository info with ssh', async () => {
       sinon.stub(pullCraft.git, 'raw').resolves('git@github.com:owner/repo.git\n');
+      const repoInfo = await pullCraft.getRepoInfo();
+      expect(repoInfo).to.deep.equal({ owner: 'owner', repo: 'repo' });
+    });
+
+    it('should get repository info with https', async () => {
+      sinon.stub(pullCraft.git, 'raw').resolves('https://github.com/owner/repo\n');
       const repoInfo = await pullCraft.getRepoInfo();
       expect(repoInfo).to.deep.equal({ owner: 'owner', repo: 'repo' });
     });


### PR DESCRIPTION
### Summary

**Type:** fix

* **What kind of change does this PR introduce?**
  This PR improves the regex used in the `getRepoInfo` method to handle different GitHub repository URL formats, including both SSH and HTTPS.

* **What is the current behavior?**
  Previously, the regex only matched URLs ending with `.git`, which failed for URLs not following this format.

* **What is the new behavior?**
  The updated regex now optionally matches the `.git` suffix and ensures it works with URLs that do not end with `.git`. This change makes the method more robust and accommodating to different URL formats.

* **Does this PR introduce a breaking change?**
  * No breaking changes are introduced with this PR.

* **Has Testing been included for this PR?**
  Yes, additional tests have been added to verify the functionality with both SSH and HTTPS URLs.

### Other Information

This change ensures that the `getRepoInfo` function can handle a wider variety of GitHub URL formats, increasing the utility and reliability of the PullCraft tool.

