### PR TITLE
fix: Correct URL trimming in PullCraft.openUrl method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ export class PullCraft {
           base: baseBranch,
           head: compareBranch
         });
-        await this.openUrl(response.data.html_url.trim()
+        await this.openUrl(response.data.html_url.trim());
       }
     } catch (error: any) {
       console.error(`Error creating PR: ${error.message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ export class PullCraft {
           base: baseBranch,
           head: compareBranch
         });
-        await this.openUrl(response.data.html_url.replace(/%0A$/, ''));
+        await this.openUrl(response.data.html_url.trim()
       }
     } catch (error: any) {
       console.error(`Error creating PR: ${error.message}`);


### PR DESCRIPTION
### Summary

**Type:** fix

* **What kind of change does this PR introduce?**
  * This PR introduces a bug fix in the URL handling within the `PullCraft.openUrl` method.

* **What is the current behavior?**
  * Previously, the method incorrectly handled the URL by trying to remove a newline character using `replace(/%0A$/, '')`, which might not correctly trim other whitespace or newline characters that could be present.

* **What is the new behavior?**
  * The URL is now properly trimmed using `trim()`, which removes all types of trailing and leading whitespace characters, ensuring the URL is clean before use.

* **Does this PR introduce a breaking change?**
  * No, this change does not introduce a breaking change but enhances the reliability of the URL handling in the application.

* **Has Testing been included for this PR?
  * No specific tests were added for this change, but existing tests should validate the absence of regressions.

### Other Information

This change ensures that the `PullCraft.openUrl` method handles URLs more reliably by properly trimming whitespace, which could potentially prevent errors in URL processing in different environments.