### PR TITLE
fix: Correct URL trimming in PullCraft.openUrl method



### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ export class PullCraft {
           base: baseBranch,
           head: compareBranch
         });
-        await this.openUrl(response.data.html_url.trim()
+        await this.openUrl(response.data.html_url.trim());
       }
     } catch (error: any) {
       console.error(`Error creating PR: ${error.message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ export class PullCraft {
           base: baseBranch,
           head: compareBranch
         });
-        await this.openUrl(response.data.html_url.replace(/%0A$/, ''));
+        await this.openUrl(response.data.html_url.trim()
       }
     } catch (error: any) {
       console.error(`Error creating PR: ${error.message}`);


### PR DESCRIPTION
### Summary

**Type:** fix

* **What kind of change does this PR introduce?**
  * This PR introduces a bug fix in the URL handling within the `PullCraft.openUrl` method.

* **What is the current behavior?**
  * Previously, the method attempted to remove a newline character from the end of the URL using a replace method that incorrectly targeted the character sequence. This approach could fail if the URL ended with different whitespace characters or multiple newline characters.

* **What is the new behavior?**
  * The URL is now trimmed using the `String.trim()` method, which effectively removes all leading and trailing whitespace characters, ensuring the URL is clean before it's opened.

* **Does this PR introduce a breaking change?**
  * No breaking changes are introduced with this PR.

* **Has Testing been included for this PR?**
  * The description does not specify testing, but testing should verify that URLs are correctly opened without leading or trailing whitespace.

### Other Information

This change ensures more robust handling of URLs, preventing errors related to formatting issues in the URL string.
