### PR TITLE
fix: Correct URL trimming in PullCraft.openUrl method



### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ export class PullCraft {
           base: baseBranch,
           head: compareBranch
         });
-        await this.openUrl(response.data.html_url.trim()
+        await this.openUrl(response.data.html_url.trim());
       }
     } catch (error: any) {
       console.error(`Error creating PR: ${error.message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ export class PullCraft {
           base: baseBranch,
           head: compareBranch
         });
-        await this.openUrl(response.data.html_url.replace(/%0A$/, ''));
+        await this.openUrl(response.data.html_url.trim()
       }
     } catch (error: any) {
       console.error(`Error creating PR: ${error.message}`);


### PR DESCRIPTION
### Summary

**Type:** fix

* **What kind of change does this PR introduce?**
  * This PR introduces a bug fix in the URL handling within the `PullCraft.openUrl` method.

* **What is the current behavior?**
  * Previously, the method attempted to remove a trailing newline from the URL using a regex that only targeted the end of the string, which was not effectively handling all whitespace or newline characters.

* **What is the new behavior?**
  * The updated code now uses the `trim()` method to remove all leading and trailing whitespace and newline characters from the URL before replacing newline characters with an empty string. This ensures the URL is correctly formatted before it's opened.

* **Does this PR introduce a breaking change?**
  * No, this change does not introduce a breaking change.

* **Has Testing been included for this PR?
  * No specific tests have been added; existing tests should ensure no regression occurs.

### Other Information

This fix improves the reliability of URL handling in scenarios where the URL may contain unexpected leading or trailing whitespace.
