### PR TITLE
fix: Correct URL trimming in PullCraft class



### DIFF
--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -212,7 +212,7 @@ class PullCraft {
                         base: baseBranch,
                         head: compareBranch
                     });
-                    yield this.openUrl(response.data.html_url.replace(/%0A$/, ''));
+                    yield this.openUrl(response.data.html_url.trim().replace('\n', ''));
                 }
             }
             catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ export class PullCraft {
           base: baseBranch,
           head: compareBranch
         });
-        await this.openUrl(response.data.html_url.replace(/%0A$/, ''));
+        await this.openUrl(response.data.html_url.trim().replace('\n', ''));
       }
     } catch (error: any) {
       console.error(`Error creating PR: ${error.message}`);


### PR DESCRIPTION
### Summary

**Type:** fix

* **What kind of change does this PR introduce?**
  * This PR introduces a bug fix in the URL handling within the `PullCraft` class.

* **What is the current behavior?**
  * Previously, the method `openUrl` was incorrectly trimming newline characters from the URL using a regex that only removed a newline at the end of the URL string.

* **What is the new behavior?**
  * The updated code now properly trims all whitespace from the URL and replaces any newline characters within the URL, ensuring the URL is correctly formatted before it's opened.

* **Does this PR introduce a breaking change?**
  * No breaking changes are introduced with this PR.

* **Has Testing been included for this PR?
  * No specific tests were mentioned for these changes. It is recommended to add tests to verify the correct trimming of URLs.

### Other Information

This change ensures that URLs are handled more robustly in scenarios where formatting issues might occur, improving the reliability of the `openUrl` method in the `PullCraft` class.
