### PR TITLE
ci: Upgrade GitHub Actions artifact actions to v4

### DIFF
--- a/.github/workflows/line_and_test.yml
+++ b/.github/workflows/line_and_test.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}     
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-artifacts
           path: coverage/

--- a/.github/workflows/line_and_test.yml
+++ b/.github/workflows/line_and_test.yml
@@ -48,6 +48,6 @@ jobs:
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-artifacts
+          name: coverage-artifacts-node-${{ matrix.node }}
           path: coverage/
       - run: ls -la

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:
-          name: coverage-artifacts
-          path: coverage
+          name: coverage-artifacts-node-22
+          path: coverage/
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage-artifacts
           path: coverage
@@ -73,7 +73,7 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage-artifacts
           path: coverage


### PR DESCRIPTION
### Summary

**Type:** ci

* **What kind of change does this PR introduce?**
  * This PR updates the GitHub Actions used for handling artifacts in our CI workflows.

* **What is the current behavior?**
  * Currently, our workflows use version 3 of \`actions/upload-artifact\` and \`actions/download-artifact\`.

* **What is the new behavior?**
  * Updated to version 4 of \`actions/upload-artifact\` and \`actions/download-artifact\` which may include improvements and bug fixes from the previous version.

* **Does this PR introduce a breaking change?**
  * No breaking changes are expected with this upgrade.

* **Has Testing been included for this PR?
  * No new tests added; existing CI workflows should validate the changes.

### Other Information

* Upgrading to the latest versions ensures we have the most recent features and fixes provided by GitHub Actions.
----