### PR TITLE
fix: Release it didn't push the full version back to main. 

### DIFF
--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -1,8 +1,8 @@
 module.exports = {
-  "git":{
+  "git": {
     "requireCleanWorkingDir": false,
     "commit": true,
-    "pushArgs": ["--tags"],
+    "pushArgs": ["--follow-tags"],
     "commitArgs": ['-a'],
     "commitMessage": 'chore: release v${version} [skip ci]'
   },
@@ -11,13 +11,11 @@ module.exports = {
     "assets": ["./build/pullcraft"]
   },
   "npm": {
-    "ignoreVersion": true,
-    "publish": true,
-    "skipChecks": true
+    "publish": true
   },
   "hooks": {
-    "before:release": "./.release-it-version.sh ${version}",
-    "after:release": "npm run build"
+    "before:bump": "./.release-it-version.sh ${version}",
+    "after:bump": "npm run build",
   },
   "plugins": {
     "@release-it/conventional-changelog": {


### PR DESCRIPTION
### Summary

**Type:** ci

* **What kind of change does this PR introduce?**
  * This PR updates the \`.release-it.cjs\` configuration to enhance the release process and build automation.

* **What is the current behavior?**
  * Previously, the release process used \`--tags\` for pushing, which might not correctly handle annotated tags. The hooks were also set to trigger on 'release' events, which could cause timing issues in the build process.

* **What is the new behavior?**
  * The \`git.pushArgs\` has been changed from \`--tags\` to \`--follow-tags\`, ensuring that both lightweight and annotated tags are pushed correctly. The hooks have been updated to trigger on 'bump' events instead of 'release', allowing for more precise control over the build process during version bumps.

* **Does this PR introduce a breaking change?**
  * No breaking changes are introduced. However, developers need to be aware of the new hook triggers when setting up their local development environments.

* **Has Testing been included for this PR?**
  * No specific new tests have been added for this configuration change. Existing tests should validate the continued functionality of the release process.

### Other Information

This update should streamline the release process and reduce potential issues with tag handling and build execution timing. It's a part of ongoing efforts to improve CI/CD workflows.
----