### PR TITLE
ci: Ignore version checks during npm publish

### DIFF
--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -1,8 +1,8 @@
 module.exports = {
-  "git":{
+  "git": {
     "requireCleanWorkingDir": false,
     "commit": true,
-    "pushArgs": ["--tags"],
+    "pushArgs": ["--follow-tags"],
     "commitArgs": ['-a'],
     "commitMessage": 'chore: release v${version} [skip ci]'
   },
@@ -11,13 +11,11 @@ module.exports = {
     "assets": ["./build/pullcraft"]
   },
   "npm": {
-    "ignoreVersion": true,
-    "publish": true,
-    "skipChecks": true
+    "publish": true
   },
   "hooks": {
-    "before:release": "./.release-it-version.sh ${version}",
-    "after:release": "npm run build"
+    "before:bump": "./.release-it-version.sh ${version}",
+    "after:bump": "npm run build",
   },
   "plugins": {
     "@release-it/conventional-changelog": {

--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -11,6 +11,7 @@ module.exports = {
     "assets": ["./build/pullcraft"]
   },
   "npm": {
+    "ignoreVersion": true,
     "publish": true
   },
   "hooks": {


### PR DESCRIPTION
### Summary

**Type:** ci

* **What kind of change does this PR introduce?**
  * This PR introduces a configuration change in the CI process specifically for npm publishing.

* **What is the current behavior?**
  * Currently, the \`.release-it.cjs\` configuration does not specify the \`ignoreVersion\` option, which means it respects version checks during npm publish.

* **What is the new behavior?**
  * With this change, the \`ignoreVersion\` flag is set to \`true\`, allowing the npm publish process to ignore version checks. This is useful in automated CI environments where version increments might not strictly follow semantic versioning.

* **Does this PR introduce a breaking change?**
  * No breaking changes are introduced. This change only affects the CI deployment process, specifically how npm handles version checks during the publish step.

* **Has Testing been included for this PR?**
  * No additional tests are included as this change pertains to CI configuration only.

### Other Information

This modification is intended to streamline CI deployments by reducing the friction caused by versioning issues during npm publish. It's particularly beneficial in continuous deployment setups where automatic version increments are handled outside of npm.

----