### PR TITLE
fix: Update release process and version handling in pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,8 +88,6 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run build
-
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -97,7 +95,16 @@ jobs:
           directory: ./coverage/
           fail_ci_if_error: true
       
-      - run: npx release-it --ci
+      - name: Bump version and create release
+        run: npx release-it --ci
+      
+      - name: Build with updated version
+        run: npm run build
+      
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   prerelease:
     needs: [lint_and_test, build_packages]
@@ -140,4 +147,14 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/
           fail_ci_if_error: true
-      - run: npx release-it --ci --preRelease=${{github.ref_name}}
+      
+      - name: Bump version and create prerelease
+        run: npx release-it --ci --preRelease=${{github.ref_name}}
+      
+      - name: Build with updated version
+        run: npm run build
+      
+      - name: Publish to npm
+        run: npm publish --tag ${{github.ref_name}}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -14,14 +14,9 @@ module.exports = {
   },
   "npm": {
     "ignoreVersion": true,
-    "publish": true,
+    "publish": false,
     "skipChecks": true
   },
-  // COMMENTED OUT BECAUSE BUNDLES NEED VERSION INJECTION FOR EACH ENVIRONMENT
-  // "hooks": {
-  //   "before:bump": "npm run inject-version",
-  //   "after:bump": "npm run build && npm run package",
-  // },
   "plugins": {
     "@release-it/conventional-changelog": {
       "whatBump": (commits,options)=>{

--- a/RELEASE-IT.md
+++ b/RELEASE-IT.md
@@ -38,7 +38,7 @@ module.exports = {
   },
   "npm": {
     "ignoreVersion": true,
-    "publish": true,
+    "publish": false,
     "skipChecks": true
   },
   "plugins": {
@@ -244,12 +244,22 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: "https://registry.npmjs.org"
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
       - run: npm ci
-      - run: npm run build --if-present
-      - run: npx release-it --ci
+      
+      - name: Bump version and create release
+        run: npx release-it --ci
+      
+      - name: Build with updated version
+        run: npm run build
+      
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   prerelease:
     needs: test
     name: PreRelease
@@ -265,12 +275,22 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: "https://registry.npmjs.org"
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
       - run: npm ci
-      - run: npm run build --if-present
-      - run: npx release-it --ci --preRelease=${{github.ref_name}}
+      
+      - name: Bump version and create prerelease
+        run: npx release-it --ci --preRelease=${{github.ref_name}}
+      
+      - name: Build with updated version
+        run: npm run build
+      
+      - name: Publish to npm
+        run: npm publish --tag ${{github.ref_name}}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
 

--- a/build/scripts/build.bundle.js
+++ b/build/scripts/build.bundle.js
@@ -6,7 +6,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 async function createBundle (options) {
-  const { entryPoint, outfile } = options;
+  const { entryPoint, outfile, version } = options;
 
   console.log('Starting bundle creation process...');
 
@@ -17,9 +17,15 @@ async function createBundle (options) {
       platform: 'node',
       target: 'node18',
       outfile,
-      format: 'cjs'
+      format: 'cjs',
+      define: version ? {
+        '__VERSION_PLACEHOLDER__': `"${version}"`
+      } : {}
     });
     console.log(`Bundle created successfully at ${outfile}`);
+    if (version) {
+      console.log(`Version ${version} injected into bundle`);
+    }
   } catch (error) {
     console.error('Bundling failed:', error);
     process.exit(1);
@@ -52,9 +58,21 @@ function validateArgs (options) {
 const cliOptions = parseArgs();
 validateArgs(cliOptions);
 
+// Read version from package.json to inject into bundle
+let version;
+try {
+  const packageJsonPath = path.join(__dirname, '../..', 'package.json');
+  const { readFileSync } = await import('fs');
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  version = packageJson.version;
+} catch (error) {
+  console.warn('Could not read version from package.json:', error.message);
+}
+
 const bundleOptions = {
   entryPoint: cliOptions.entryPoint,
-  outfile: cliOptions.outfile || path.join(__dirname, '..', 'bundle.js')
+  outfile: cliOptions.outfile || path.join(__dirname, '..', 'bundle.js'),
+  version
 };
 
 createBundle(bundleOptions).catch(console.error);

--- a/build/scripts/build.sea.js
+++ b/build/scripts/build.sea.js
@@ -60,7 +60,7 @@ async function createSEA (options) {
   console.log('Permissions set');
 
   // Step 3: Generate the blob
-  const generateBlobCommand = `node --experimental-sea-config ${seaConfigPath} --experimental-default-type=module`;
+  const generateBlobCommand = `node --experimental-sea-config ${seaConfigPath}`;
   console.log(`Generating blob: ${generateBlobCommand}`);
   execSync(generateBlobCommand, { stdio: 'inherit' });
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "rm -rf ./dist/cjs && tsc -p tsconfig.cjs.json && chmod +x ./dist/cjs/bin/pullcraft.js",
+    "build:cjs": "rm -rf ./dist/cjs && tsc -p tsconfig.cjs.json",
     "build:esm": "rm -rf ./dist/esm && tsc -p tsconfig.esm.json && chmod +x ./dist/esm/bin/pullcraft.js",
     "build:bundle": "rm -f ./build/bundle.js && node ./build/scripts/build.bundle.js --entryPoint ./dist/esm/bin/pullcraft.js",
     "build:sea": "node ./build/scripts/build.sea.js --binaryName pullcraft",

--- a/src/bin/pullcraft.ts
+++ b/src/bin/pullcraft.ts
@@ -3,8 +3,19 @@
 import PullCraft from '../index.js'; // Adjust the path to where your PullCraft class is located
 import dotenv from 'dotenv';
 import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 
-const VERSION = '__VERSION__';
+// Read version from package.json
+// This bin file is only used from the ESM build (see package.json "bin" field)
+// When compiled, this file is at dist/esm/bin/pullcraft.js
+// package.json is at the root, so we go up 3 levels
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJsonPath = join(__dirname, '../../../package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const VERSION = packageJson.version;
 
 // Load environment variables from a .env file if it exists
 dotenv.config();

--- a/src/bin/pullcraft.ts
+++ b/src/bin/pullcraft.ts
@@ -8,14 +8,24 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
 // Read version from package.json
-// This bin file is only used from the ESM build (see package.json "bin" field)
-// When compiled, this file is at dist/esm/bin/pullcraft.js
-// package.json is at the root, so we go up 3 levels
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const packageJsonPath = join(__dirname, '../../../package.json');
-const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-const VERSION = packageJson.version;
+// For npm installs: read from package.json at runtime
+// For SEA bundles: VERSION_PLACEHOLDER is replaced at build time by esbuild
+let VERSION = '__VERSION_PLACEHOLDER__';
+
+// If running from npm install (not bundled), read version from package.json
+if (VERSION === '__VERSION_PLACEHOLDER__') {
+  try {
+    if (import.meta.url) {
+      const __filename = fileURLToPath(import.meta.url);
+      const __dirname = dirname(__filename);
+      const packageJsonPath = join(__dirname, '../../../package.json');
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+      VERSION = packageJson.version;
+    }
+  } catch (error) {
+    VERSION = '0.0.0-dev';
+  }
+}
 
 // Load environment variables from a .env file if it exists
 dotenv.config();

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -4,5 +4,8 @@
     "module": "commonjs",
     "moduleResolution": "Node",
     "outDir": "./dist/cjs"
-  }
+  },
+  "exclude": [
+    "src/bin/**/*"
+  ]
 }


### PR DESCRIPTION
### Summary

**Type:** fix

* **What kind of change does this PR introduce?**
  * This PR introduces changes to the release and build process in the CI/CD pipeline, and updates how the version is handled in the \`pullcraft.ts\` script.

* **What is the current behavior?**
  * Previously, the version was a placeholder and the build step was run before the release step in the CI/CD pipeline.

* **What is the new behavior?**
  * The version is now dynamically pulled from \`package.json\`, ensuring accuracy. The build step now occurs after the release step in the CI/CD pipeline, which includes changes to both the release and prerelease workflows. Additionally, the npm publish step has been added directly after building.

* **Does this PR introduce a breaking change?**
  * No breaking changes are introduced. However, the order of operations in the CI/CD pipeline has changed, which could affect how builds and releases are handled.

* **Has Testing been included for this PR?
  * No specific new tests were added; existing CI/CD workflows should validate these changes.

### Other Information

* The changes ensure that the build uses the most recent version number, which is crucial for accurate releases. The modification in \`.release-it.cjs\` to disable automatic npm publishing aligns with the new manual publish steps added in the GitHub Actions workflow.

* This update is crucial for maintaining accurate versioning and improving the reliability of the release process in automated environments.

----